### PR TITLE
Use URLSearchParams for option parsing

### DIFF
--- a/autocruise.js
+++ b/autocruise.js
@@ -88,12 +88,9 @@ Currently defined parameters are:
             }
         }
         // take options from URL
-        let search = window.location.search.split('?')[1];
-        if (search) {
-            for(let kv of search.split('&')) {
-                let [key, value] = kv.split('=');
-                options[key] = decodeURIComponent(value);
-            }
+        const params = new URLSearchParams(window.location.search);
+        for (const [key, value] of params.entries()) {
+            options[key] = value;
         }
 
         if (parseFloat(attributes.interval??0) > 0) {


### PR DESCRIPTION
## Summary
- replace manual URL query parsing with URLSearchParams for robust option handling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c99c2bc5a4832b8fca9333a6e8479c