### PR TITLE
Add Jest tests for loadConfig query parsing and error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/autocruise.js
+++ b/autocruise.js
@@ -64,6 +64,18 @@ Currently defined parameters are:
         return Math.floor((new Date()).getTime()/1000.0);
     }
 
+    function escapeHtml(value) {
+        if (value == null) {
+            return '';
+        }
+        return String(value)
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#39;");
+    }
+
     
     function loadConfig(then) {
         let config = {
@@ -119,10 +131,12 @@ Currently defined parameters are:
                     return response.json();
                 })
                 .catch(e => {
+                    const escapedUrl = escapeHtml(options.config);
+                    const escapedError = escapeHtml(e.message);
                     document.write(`
                         <h3>Autocruise Configuration Error</h3>
-                         URL: ${options.config}<br>
-                         Error: ${e.message}
+                         URL: ${escapedUrl}<br>
+                         Error: ${escapedError}
                     `);
                     return null;
                 })
@@ -416,7 +430,18 @@ Currently defined parameters are:
         }
     }
 
-    
+
+    if (typeof window !== 'undefined') {
+        window.autocruise = window.autocruise || {};
+        window.autocruise.loadConfig = loadConfig;
+    }
+    if (typeof module !== 'undefined' && module.exports) {
+        module.exports = {
+            loadConfig,
+        };
+    }
+
+
     window.addEventListener('DOMContentLoaded', e => {
         loadConfig((config) => {
             if (config.pages.length == 0) {

--- a/package.json
+++ b/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "autocruise",
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "jest"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
+}

--- a/tests/loadConfig.test.js
+++ b/tests/loadConfig.test.js
@@ -1,0 +1,54 @@
+const { loadConfig } = require('../autocruise.js');
+
+describe('loadConfig', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '<a href="fallback">fallback</a>';
+  });
+
+  afterEach(() => {
+    if (global.fetch && typeof global.fetch.mockClear === 'function') {
+      global.fetch.mockClear();
+    }
+    delete global.fetch;
+    document.body.innerHTML = '';
+    window.history.replaceState({}, '', '/');
+  });
+
+  const runLoadConfig = () =>
+    new Promise(resolve => {
+      loadConfig(resolve);
+    });
+
+  test('parses nested query parameters for config, interval, and view', async () => {
+    const remoteConfig = 'https://cdn.example.com/config.json?inner=1%26two=2';
+    window.history.replaceState({}, '', `/?config=${remoteConfig}&interval=120&view=tile`);
+
+    const mockResponse = {
+      ok: true,
+      json: async () => ({
+        interval: 45,
+        view: 'cycle',
+        pages: ['https://remote/page'],
+      }),
+    };
+    global.fetch = jest.fn().mockResolvedValue(mockResponse);
+
+    const config = await runLoadConfig();
+
+    expect(global.fetch).toHaveBeenCalledWith('https://cdn.example.com/config.json?inner=1&two=2');
+    expect(config.interval).toBe(120);
+    expect(config.view).toBe('tile');
+    expect(config.pages).toEqual(['https://remote/page']);
+  });
+
+  test('writes escaped error message when fetch fails', async () => {
+    window.history.replaceState({}, '', '/?config=<script>alert("xss")</script>');
+    global.fetch = jest.fn().mockRejectedValue(new Error('<boom> & fail'));
+
+    await runLoadConfig();
+
+    expect(document.body.innerHTML).toContain('&lt;script&gt;alert(&quot;xss&quot;)&lt;/script&gt;');
+    expect(document.body.innerHTML).not.toContain('<script>');
+    expect(document.body.innerHTML).toContain('&lt;boom&gt; &amp; fail');
+  });
+});


### PR DESCRIPTION
## Summary
- add an escapeHtml helper so loadConfig reports fetch errors safely
- expose loadConfig for tests and create a Jest suite exercising nested query parsing
- add a package.json with a convenient npm test script for the new Jest suite

## Testing
- npm test *(fails in the execution environment because jest is not installed yet)*

------
https://chatgpt.com/codex/tasks/task_e_68c9ac9a5658832b804e3f34732bd77c